### PR TITLE
Remove use_external_viewer flag and implement auto-detection

### DIFF
--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -1,0 +1,177 @@
+"""Tests for auto-detection functionality (Issue #23)."""
+
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from napari_mcp.server import (
+    _detect_external_viewer,
+    init_viewer,
+)
+
+
+class TestAutoDetection:
+    """Test auto-detection of napari-mcp server."""
+
+    @pytest.mark.asyncio
+    @patch("napari_mcp.server.Client")
+    async def test_init_viewer_auto_detects_external(self, mock_client_class):
+        """Test that init_viewer automatically detects external server."""
+        # Setup mock client
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        # Mock session info for external server
+        mock_result = Mock()
+        mock_info = {
+            "session_type": "napari_bridge_session",
+            "viewer": {"title": "External Viewer", "layer_names": ["Layer1"]},
+            "bridge_port": 9999,
+        }
+        mock_result.content = [Mock(text=json.dumps(mock_info))]
+        mock_client.call_tool.return_value = mock_result
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        # Test auto-detection without explicit use_external parameter
+        with patch("napari_mcp.server._viewer_lock", asyncio.Lock()):
+            result = await init_viewer(title="Test Viewer")
+
+        assert result["status"] == "ok"
+        assert result["viewer_type"] == "external"
+        assert result["title"] == "External Viewer"
+        assert result["port"] == 9999
+
+    @pytest.mark.asyncio
+    @patch("napari_mcp.server.Client")
+    async def test_init_viewer_custom_port_detection(self, mock_client_class):
+        """Test that init_viewer can detect external server on custom port."""
+        # Setup mock client
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        # Mock session info for external server on custom port
+        mock_result = Mock()
+        mock_info = {
+            "session_type": "napari_bridge_session",
+            "viewer": {"title": "Custom Port Viewer", "layer_names": []},
+            "bridge_port": 8888,
+        }
+        mock_result.content = [Mock(text=json.dumps(mock_info))]
+        mock_client.call_tool.return_value = mock_result
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        # Test detection with custom port
+        with patch("napari_mcp.server._viewer_lock", asyncio.Lock()):
+            result = await init_viewer(port=8888)
+
+        assert result["status"] == "ok"
+        assert result["viewer_type"] == "external"
+        assert result["port"] == 8888
+
+        # Verify client was created with custom port
+        mock_client_class.assert_called_with("http://localhost:8888/mcp")
+
+    @pytest.mark.asyncio
+    async def test_init_viewer_fallback_to_local(self):
+        """Test that init_viewer falls back to local when no external server."""
+        mock_viewer = Mock()
+        mock_viewer.title = "Local Viewer"
+        mock_viewer.layers = []
+        mock_viewer.window = Mock()
+        mock_viewer.window.qt_viewer = Mock()
+        mock_viewer.window.qt_viewer.canvas = Mock()
+        mock_viewer.window.qt_viewer.canvas.size = Mock(
+            return_value=Mock(
+                width=Mock(return_value=800), height=Mock(return_value=600)
+            )
+        )
+
+        # Mock failed external detection (no server running)
+        with (
+            patch("napari_mcp.server._detect_external_viewer", return_value=(None, None)),
+            patch("napari_mcp.server._ensure_viewer", return_value=mock_viewer),
+            patch("napari_mcp.server._viewer_lock", asyncio.Lock()),
+            patch("napari_mcp.server._process_events"),
+        ):
+            result = await init_viewer(title="Test")
+
+        assert result["status"] == "ok"
+        assert result["viewer_type"] == "local"
+        assert result["title"] == "Local Viewer"
+
+    @pytest.mark.asyncio
+    @patch("napari_mcp.server.Client")
+    async def test_init_viewer_env_var_port_override(self, mock_client_class):
+        """Test that environment variable port can be overridden by parameter."""
+        # Setup mock client
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        # Mock session info
+        mock_result = Mock()
+        mock_info = {
+            "session_type": "napari_bridge_session",
+            "viewer": {"title": "Override Test", "layer_names": []},
+            "bridge_port": 7777,
+        }
+        mock_result.content = [Mock(text=json.dumps(mock_info))]
+        mock_client.call_tool.return_value = mock_result
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        # Mock environment variable for default port
+        with (
+            patch.dict(os.environ, {"NAPARI_MCP_BRIDGE_PORT": "9999"}),
+            patch("napari_mcp.server._viewer_lock", asyncio.Lock()),
+        ):
+            # Override with port parameter
+            result = await init_viewer(port=7777)
+
+        assert result["status"] == "ok"
+        assert result["viewer_type"] == "external"
+        assert result["port"] == 7777
+
+        # Verify client was created with override port, not env var
+        mock_client_class.assert_called_with("http://localhost:7777/mcp")
+
+    @pytest.mark.asyncio
+    @patch("napari_mcp.server.Client")
+    async def test_init_viewer_connection_failure_fallback(self, mock_client_class):
+        """Test fallback to local when external server connection fails."""
+        # Setup mock client that raises exception
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+        mock_client.__aenter__ = AsyncMock(side_effect=ConnectionError("Connection failed"))
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        mock_viewer = Mock()
+        mock_viewer.title = "Fallback Local"
+        mock_viewer.layers = []
+        mock_viewer.window = Mock()
+        mock_viewer.window.qt_viewer = Mock()
+        mock_viewer.window.qt_viewer.canvas = Mock()
+        mock_viewer.window.qt_viewer.canvas.size = Mock(
+            return_value=Mock(
+                width=Mock(return_value=800), height=Mock(return_value=600)
+            )
+        )
+
+        with (
+            patch("napari_mcp.server._ensure_viewer", return_value=mock_viewer),
+            patch("napari_mcp.server._viewer_lock", asyncio.Lock()),
+            patch("napari_mcp.server._process_events"),
+        ):
+            result = await init_viewer()
+
+        assert result["status"] == "ok"
+        assert result["viewer_type"] == "local"
+        assert result["title"] == "Fallback Local"

--- a/tests/test_external_viewer.py
+++ b/tests/test_external_viewer.py
@@ -16,7 +16,6 @@ from napari_mcp.server import (
     _parse_bool,
     _proxy_to_external,
     detect_viewers,
-    select_viewer,
 )
 
 
@@ -158,20 +157,19 @@ class TestProxyFunctionality:
     """Test proxying tool calls to external viewer."""
 
     @pytest.mark.asyncio
-    @patch("napari_mcp.server._use_external", True)
-    @patch("napari_mcp.server.Client")
-    async def test_proxy_to_external_success(self, mock_client_class):
+    @patch("napari_mcp.server._detect_external_viewer")
+    async def test_proxy_to_external_success(self, mock_detect):
         """Test successful proxy to external viewer."""
-        # Setup mock client instance
+        # Setup mock client and detection
         mock_client_instance = AsyncMock()
         mock_result = Mock()
         mock_result.content = [Mock(text='{"status": "ok", "result": "test"}')]
         mock_client_instance.call_tool.return_value = mock_result
-
-        # Mock Client class to return our mock instance
-        mock_client_class.return_value = mock_client_instance
         mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
         mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+
+        mock_info = {"session_type": "napari_bridge_session", "bridge_port": 9999}
+        mock_detect.return_value = (mock_client_instance, mock_info)
 
         result = await _proxy_to_external("test_tool", {"param": "value"})
 
@@ -181,51 +179,50 @@ class TestProxyFunctionality:
         mock_client_instance.call_tool.assert_called_once_with(
             "test_tool", {"param": "value"}
         )
-        mock_client_class.assert_called_once_with("http://localhost:9999/mcp")
 
     @pytest.mark.asyncio
-    @patch("napari_mcp.server._use_external", False)
-    async def test_proxy_to_external_disabled(self):
-        """Test proxy when external viewer is disabled."""
+    @patch("napari_mcp.server._detect_external_viewer")
+    async def test_proxy_to_external_no_external(self, mock_detect):
+        """Test proxy when no external viewer available."""
+        mock_detect.return_value = (None, None)
+        
         result = await _proxy_to_external("test_tool", {"param": "value"})
         assert result is None
 
     @pytest.mark.asyncio
-    @patch("napari_mcp.server._use_external", True)
-    @patch("napari_mcp.server.Client")
-    async def test_proxy_to_external_initialize_client(self, mock_client_class):
-        """Test proxy initializes client if not present."""
-        # Setup mock client
-        mock_client = AsyncMock()
-        mock_client_class.return_value = mock_client
-
+    @patch("napari_mcp.server._detect_external_viewer")  
+    async def test_proxy_to_external_custom_port(self, mock_detect):
+        """Test proxy with custom port."""
+        mock_client_instance = AsyncMock()
         mock_result = Mock()
         mock_result.content = [Mock(text='{"status": "ok"}')]
-        mock_client.call_tool.return_value = mock_result
+        mock_client_instance.call_tool.return_value = mock_result
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
 
-        # Mock context manager
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_info = {"session_type": "napari_bridge_session", "bridge_port": 8888}
+        mock_detect.return_value = (mock_client_instance, mock_info)
 
-        result = await _proxy_to_external("test_tool")
+        result = await _proxy_to_external("test_tool", port=8888)
 
         assert result is not None
         assert result["status"] == "ok"
-        mock_client_class.assert_called_once_with("http://localhost:9999/mcp")
+        # Verify custom port was passed to detect function
+        mock_detect.assert_called_once_with(8888)
 
     @pytest.mark.asyncio
-    @patch("napari_mcp.server._use_external", True)
-    @patch("napari_mcp.server.Client")
-    async def test_proxy_to_external_invalid_json(self, mock_client_class):
+    @patch("napari_mcp.server._detect_external_viewer")
+    async def test_proxy_to_external_invalid_json(self, mock_detect):
         """Test proxy with invalid JSON response."""
         mock_client_instance = AsyncMock()
         mock_result = Mock()
         mock_result.content = [Mock(text="invalid json")]
         mock_client_instance.call_tool.return_value = mock_result
-
-        mock_client_class.return_value = mock_client_instance
         mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
         mock_client_instance.__aexit__ = AsyncMock(return_value=None)
+
+        mock_info = {"session_type": "napari_bridge_session", "bridge_port": 9999}
+        mock_detect.return_value = (mock_client_instance, mock_info)
 
         result = await _proxy_to_external("test_tool")
 
@@ -234,8 +231,8 @@ class TestProxyFunctionality:
         assert "Invalid JSON response" in result["message"]
 
 
-class TestViewerDetectionAndSelection:
-    """Test detect_viewers and select_viewer functions."""
+class TestViewerDetection:
+    """Test detect_viewers function."""
 
     @pytest.mark.asyncio
     @patch("napari_mcp.server._detect_external_viewer")
@@ -250,12 +247,15 @@ class TestViewerDetectionAndSelection:
         assert result["viewers"]["external"]["available"] is False
         assert result["viewers"]["local"]["available"] is True
         assert result["viewers"]["local"]["type"] == "not_initialized"
+        assert result["auto_detect"] is True
+        assert result["preference"] == "external_if_available"
 
     @pytest.mark.asyncio
     @patch("napari_mcp.server._detect_external_viewer")
     async def test_detect_viewers_with_external(self, mock_detect):
         """Test detecting viewers with external available."""
-        mock_client = Mock()
+        mock_client = AsyncMock()
+        mock_client.close = AsyncMock()
         mock_info = {"bridge_port": 9999, "viewer": {"title": "External"}}
         mock_detect.return_value = (mock_client, mock_info)
 
@@ -265,78 +265,5 @@ class TestViewerDetectionAndSelection:
         assert result["viewers"]["external"]["available"] is True
         assert result["viewers"]["external"]["type"] == "napari_bridge"
         assert result["viewers"]["external"]["port"] == 9999
+        mock_client.close.assert_called_once()  # Ensure client is closed after detection
 
-    @pytest.mark.asyncio
-    @patch("napari_mcp.server._detect_external_viewer")
-    async def test_select_viewer_external(self, mock_detect):
-        """Test selecting external viewer."""
-        mock_client = AsyncMock()
-        mock_info = {"test": "info"}
-        mock_detect.return_value = (mock_client, mock_info)
-
-        result = await select_viewer(use_external=True)
-
-        assert result["status"] == "ok"
-        assert result["selected"] == "external"
-        assert result["info"] == mock_info
-
-    @pytest.mark.asyncio
-    @patch("napari_mcp.server._detect_external_viewer")
-    async def test_select_viewer_external_not_found(self, mock_detect):
-        """Test selecting external viewer when not available."""
-        mock_detect.return_value = (None, None)
-
-        result = await select_viewer(use_external=True)
-
-        assert result["status"] == "error"
-        assert "not found" in result["message"]
-        assert result["fallback"] == "local"
-
-    @pytest.mark.asyncio
-    async def test_select_viewer_local(self):
-        """Test selecting local viewer."""
-        result = await select_viewer(use_external=False)
-
-        assert result["status"] == "ok"
-        assert result["selected"] == "local"
-
-    @pytest.mark.asyncio
-    @patch("napari_mcp.server._detect_external_viewer")
-    async def test_select_viewer_auto_detect(self, mock_detect):
-        """Test auto-detecting viewer preference."""
-        # With external available
-        mock_client = AsyncMock()
-        mock_detect.return_value = (mock_client, {"test": "info"})
-
-        result = await select_viewer(use_external=None)
-        assert result["selected"] == "external"
-
-        # Without external available
-        mock_detect.return_value = (None, None)
-
-        result = await select_viewer(use_external=None)
-        assert result["selected"] == "local"
-
-    @pytest.mark.asyncio
-    @patch("napari_mcp.server._detect_external_viewer")
-    async def test_select_viewer_string_parsing(self, mock_detect):
-        """Test selecting viewer with string parameter."""
-        mock_client = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_detect.return_value = (mock_client, {"test": "info"})
-
-        # Test string "true"
-        result = await select_viewer(use_external="true")
-        assert result["selected"] == "external"
-
-        # Test string "false"
-        result = await select_viewer(use_external="false")
-        assert result["selected"] == "local"
-
-        # Test string "1"
-        result = await select_viewer(use_external="1")
-        assert result["selected"] == "external"
-
-        # Test string "no"
-        result = await select_viewer(use_external="no")
-        assert result["selected"] == "local"


### PR DESCRIPTION
Removes the `use_external_viewer` flag and implements automatic detection of running napari-mcp servers.

## Changes
- ✅ Remove global `_use_external` flag and `use_external` parameter
- ✅ Add auto-detection: `init_viewer()` automatically finds external servers
- ✅ Add `port` parameter for custom port specification
- ✅ Enhanced widget warnings for non-default ports
- ✅ Remove `select_viewer()` function (no longer needed)
- ✅ Update all tests and add comprehensive coverage

## Breaking Changes
- `use_external` parameter removed from `init_viewer()`
- `select_viewer()` function removed
- `NAPARI_MCP_USE_EXTERNAL` environment variable no longer used

Closes #23

Generated with [Claude Code](https://claude.ai/code)