### PR TITLE
tests: align screenshot to FastMCP Image; fix no-viewer checks

### DIFF
--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -24,14 +24,14 @@ from napari_mcp.server import (  # noqa: E402
     remove_layer,
     reorder_layer,
     screenshot,
+    # set_zoom removed; use set_camera(zoom=...)
+    session_information,
     set_active_layer,
     set_camera,
     set_dims_current_step,
     set_grid,
     set_layer_properties,
     set_ndisplay,
-    # set_zoom removed; use set_camera(zoom=...)
-    session_information,
 )
 
 
@@ -232,8 +232,8 @@ async def test_screenshot_with_different_dtypes(make_napari_viewer):
 
     # Take screenshot - should work with any data type napari supports
     res = await screenshot()
-    assert res["mime_type"] == "image/png"
-    assert "base64_data" in res
+    assert res._format.lower() in ("png", "image/png")
+    assert res.data is not None
 
     # Clean up viewer
     await close_viewer()

--- a/tests/test_napari_server_coverage.py
+++ b/tests/test_napari_server_coverage.py
@@ -16,6 +16,7 @@ from napari_mcp.server import (
     add_points,
     close_viewer,
     execute_code,
+    init_viewer,
     install_packages,
     list_layers,
     reset_view,
@@ -23,7 +24,6 @@ from napari_mcp.server import (
     session_information,
     set_active_layer,
     set_ndisplay,
-    init_viewer,
 )
 
 
@@ -43,7 +43,8 @@ async def test_error_handling_with_no_viewer(make_napari_viewer):
         assert result == []
 
         result = await screenshot()
-        assert "error" in result.get("status", "") or "mime_type" in result
+        assert result._format.lower() in ("png", "image/png")
+        assert result.data is not None
 
         result = await reset_view()
         assert result["status"] == "ok"  # reset_view creates viewer if needed


### PR DESCRIPTION
Isolates test updates only; avoids commits merged via #22. Accept FastMCP Image for screenshot (data+format). Adjust no-viewer assertions. Supersedes draft #28.