### PR TITLE
Fix bridge server crash with newer FastMCP versions

### DIFF
--- a/src/napari_mcp/bridge_server.py
+++ b/src/napari_mcp/bridge_server.py
@@ -119,7 +119,13 @@ class NapariBridgeServer:
         # Remove lifecycle tools that should not be available in bridge mode
         # (the viewer is managed by napari, not the agent)
         for name in ("close_viewer", "init_viewer"):
-            self.server._tool_manager._tools.pop(name, None)
+            try:
+                self.server.remove_tool(name)
+            except (AttributeError, Exception):
+                try:
+                    self.server._tool_manager._tools.pop(name, None)
+                except (AttributeError, Exception):
+                    pass
 
         # Override the 3 tools that differ in bridge mode
         self._register_bridge_overrides()

--- a/src/napari_mcp/bridge_server.py
+++ b/src/napari_mcp/bridge_server.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+
+logger = logging.getLogger(__name__)
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import TYPE_CHECKING, Any
@@ -121,11 +123,13 @@ class NapariBridgeServer:
         for name in ("close_viewer", "init_viewer"):
             try:
                 self.server.remove_tool(name)
-            except (AttributeError, Exception):
+            except AttributeError:
                 try:
                     self.server._tool_manager._tools.pop(name, None)
-                except (AttributeError, Exception):
-                    pass
+                except AttributeError:
+                    logger.debug("Could not remove tool %r using any method", name)
+            except Exception as e:
+                logger.debug("remove_tool(%r) failed unexpectedly: %s", name, e)
 
         # Override the 3 tools that differ in bridge mode
         self._register_bridge_overrides()


### PR DESCRIPTION
## Summary
- `NapariBridgeServer.__init__` crashes with `AttributeError: 'FastMCP' object has no attribute '_tool_manager'` on newer versions of FastMCP
- Uses the public `remove_tool()` API instead, with a fallback to the old `_tool_manager._tools.pop()` for backward compatibility
- If both methods fail, silently passes (the tools may simply not exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made lifecycle tool removal during startup more robust: now uses the public removal mechanism with safe fallbacks and quieter error handling to reduce initialization disruptions and noisy logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->